### PR TITLE
Check if the client is run in a browser before trying to access cookies

### DIFF
--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -336,6 +336,8 @@ SCSocket.prototype._onSCClose = function (reconnect) {
 };
 
 SCSocket.prototype._setCookie = function (name, value, expirySeconds) {
+  if (typeof document === 'undefined') return;
+
   var exdate = null;
   if (expirySeconds) {
     exdate = new Date();
@@ -346,6 +348,8 @@ SCSocket.prototype._setCookie = function (name, value, expirySeconds) {
 };
 
 SCSocket.prototype._getCookie = function (name) {
+  if (typeof document === 'undefined') return;
+
   var i, x, y, ARRcookies = document.cookie.split(';');
   for (i = 0; i < ARRcookies.length; i++) {
     x = ARRcookies[i].substr(0, ARRcookies[i].indexOf('='));


### PR DESCRIPTION
This just fixes a silly bug when trying to connect to a SocketCluster 1 server from Node.js, which uses authorization. In such a case the program will die because `document.cookie` doesn't exist, so I have added a check for that.