### PR TITLE
Make autoProcessSubscriptions behaviour work when new subscriptions are made

### DIFF
--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -40,6 +40,7 @@ var SCSocket = function (options) {
 
   this.id = null;
   this.state = this.CLOSED;
+  this.pendingConnectCallback = false;
 
   this.ackTimeout = opts.ackTimeout;
 
@@ -378,6 +379,8 @@ SCSocket.prototype._onSCOpen = function (status) {
   this._connectAttempts = 0;
   if (this.options.autoProcessSubscriptions) {
     this.processPendingSubscriptions();
+  } else {
+    this.pendingConnectCallback = true;
   }
 
   // If the user invokes the callback while in autoProcessSubscriptions mode, it
@@ -591,7 +594,7 @@ SCSocket.prototype._trySubscribe = function (channel) {
   var self = this;
 
   // We can only ever have one pending subscribe action at any given time on a channel
-  if (this.state == this.OPEN && channel._pendingSubscriptionCid == null) {
+  if (this.state == this.OPEN && !this.pendingConnectCallback && channel._pendingSubscriptionCid == null) {
     var options = {
       noTimeout: true
     };
@@ -724,6 +727,8 @@ SCSocket.prototype.isSubscribed = function (channel, includePending) {
 
 SCSocket.prototype.processPendingSubscriptions = function () {
   var self = this;
+
+  this.pendingConnectCallback = false;
 
   var channels = [];
   for (var channelName in this._channels) {


### PR DESCRIPTION
This makes new subscriptions become pending instead of being attempted immediately if autoProcessSubscriptions is false and the user has not yet called the processSubscriptions task following the socket becoming open.