### PR TITLE
Removed double error throw for subscribeFail

### DIFF
--- a/lib/sctransport.js
+++ b/lib/sctransport.js
@@ -164,7 +164,7 @@ SCTransport.prototype._onMessage = function (message) {
           eventObject.callback(obj.error, obj.data);
         }
       }
-      if (obj.error) {
+      if (obj.error && eventObject.event !== "#subscribe") {
         this._onError(obj.error);
       }
     } else {


### PR DESCRIPTION
Currently, if a sub fails, it calls the `subscribeFail` callback, which is good. However, It additionally emits an `error`, which is bad. No reason to emit the same error across 2 channels! Additionally, the error it emits is just a string (bad), whereas all other errors are error objects (good). 

Pretty sure this is a bug, so I closed it up.