### PR TITLE
Wait for auth multiplex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea

--- a/index.js
+++ b/index.js
@@ -10,4 +10,4 @@ module.exports.connect = function (options) {
   return SCSocketCreator(options);
 };
 
-module.exports.version = '2.4.1';
+module.exports.version = '3.1.0';

--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 var SCSocket = require('./lib/scsocket');
+var SCSocketCreator = require('./lib/scsocketCreator');
+
+module.exports.SCSocketCreator = SCSocketCreator;
 module.exports.SCSocket = SCSocket;
 
 module.exports.SCEmitter = require('sc-emitter').SCEmitter;
 
 module.exports.connect = function (options) {
-  return new SCSocket(options);
+  return SCSocketCreator(options);
 };
 
-module.exports.version = '3.0.0';
+module.exports.version = '2.4.1';

--- a/index.js
+++ b/index.js
@@ -7,7 +7,11 @@ module.exports.SCSocket = SCSocket;
 module.exports.SCEmitter = require('sc-emitter').SCEmitter;
 
 module.exports.connect = function (options) {
-  return SCSocketCreator(options);
+  return SCSocketCreator.connect(options);
+};
+
+module.exports.destroy = function (options) {
+  return SCSocketCreator.destroy(options);
 };
 
 module.exports.version = '3.2.0';

--- a/index.js
+++ b/index.js
@@ -10,4 +10,4 @@ module.exports.connect = function (options) {
   return SCSocketCreator(options);
 };
 
-module.exports.version = '3.1.0';
+module.exports.version = '3.2.0';

--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -5,6 +5,7 @@ var AuthEngine = require('./auth').AuthEngine;
 var SCTransport = require('./sctransport').SCTransport;
 var querystring = require('querystring');
 var LinkedList = require('linked-list');
+var jwtDecode = require('jwt-decode');
 
 if (!Object.create) {
   Object.create = require('./objectcreate');
@@ -21,7 +22,8 @@ var SCSocket = function (opts) {
   this.id = null;
   this.state = this.CLOSED;
   this.pendingConnectCallback = false;
-
+  this.isAuthenticated = false;
+  this._tokenExpiration = null;
   this.ackTimeout = opts.ackTimeout;
 
   // pingTimeout will be ackTimeout at the start, but it will
@@ -191,6 +193,7 @@ SCSocket.prototype._privateEventHandlerMap = {
       };
 
       this.auth.saveToken(this.options.authTokenName, data.token, {}, triggerAuthenticate);
+      self._setAuthStatus(data.token);
     } else {
       response.error('No token data provided by #setAuthToken event');
     }
@@ -198,6 +201,7 @@ SCSocket.prototype._privateEventHandlerMap = {
   '#removeAuthToken': function (data, response) {
     var self = this;
 
+    this._setAuthStatus();
     this.auth.removeToken(this.options.authTokenName, function (err) {
       if (err) {
         // Non-fatal error - Do not close the connection
@@ -210,6 +214,7 @@ SCSocket.prototype._privateEventHandlerMap = {
     });
   },
   '#disconnect': function (data) {
+    this._setAuthStatus();
     this.transport.close(data.code, data.data);
   }
 };
@@ -313,6 +318,7 @@ SCSocket.prototype.authenticate = function (signedAuthToken, callback) {
         if (err) {
           self._onSCError(err);
         } else if (authStatus.isAuthenticated) {
+          self._setAuthStatus(authStatus.isAuthenticated);
           SCEmitter.prototype.emit.call(self, 'authenticate', signedAuthToken);
         }
       });
@@ -353,6 +359,7 @@ SCSocket.prototype._onSCOpen = function (status) {
     this.id = status.id;
     this.pingTimeout = status.pingTimeout;
     this.transport.pingTimeout = this.pingTimeout;
+    this._setAuthStatus(status.authToken);
   }
 
   this._connectAttempts = 0;
@@ -748,5 +755,21 @@ SCSocket.prototype.unwatch = function (channelName, handler) {
 SCSocket.prototype.watchers = function (channelName) {
   return this._channelEmitter.listeners(channelName);
 };
+
+SCSocket.prototype._setAuthStatus = function(encodedAuthToken) {
+  var self = this;
+  if (!encodedAuthToken) {
+    this.isAuthenticated = false;
+    return clearTimeout(this._tokenExpiration);
+  }
+  var decodedToken = jwtDecode(encodedAuthToken);
+  var expiration = decodedToken.exp;
+  if (!expiration) throw new Error('JWT does not have expiration');
+  var ttl = expiration - Date.now();
+  this.isAuthenticated = true;
+  this._tokenExpiration = setTimeout(function() {
+    self.isAuthenticated = false
+  }, ttl)
+}
 
 module.exports = SCSocket;

--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -13,30 +13,10 @@ if (!Object.create) {
 var isBrowser = typeof window != 'undefined';
 
 
-var SCSocket = function (options) {
+var SCSocket = function (opts) {
   var self = this;
 
   SCEmitter.call(this);
-
-  var opts = {
-    port: null,
-    autoReconnect: true,
-    autoProcessSubscriptions: true,
-    ackTimeout: 10000,
-    hostname: global.location && location.hostname,
-    path: '/socketcluster/',
-    secure: global.location && location.protocol == 'https:',
-    timestampRequests: false,
-    timestampParam: 't',
-    authEngine: null,
-    authTokenName: 'socketCluster.authToken',
-    binaryType: 'arraybuffer'
-  };
-  for (var i in options) {
-    if (options.hasOwnProperty(i)) {
-      opts[i] = options[i];
-    }
-  }
 
   this.id = null;
   this.state = this.CLOSED;
@@ -94,6 +74,7 @@ var SCSocket = function (options) {
       this.options.autoReconnectOptions = {};
     }
 
+    //should reconnectOptions be part of the "this" object? I don't think it does anything
     var reconnectOptions = this.options.autoReconnectOptions;
     if (reconnectOptions.initialDelay == null) {
       reconnectOptions.initialDelay = 10000;
@@ -125,9 +106,6 @@ var SCSocket = function (options) {
   if (typeof this.options.query == 'string') {
     this.options.query = querystring.parse(this.options.query);
   }
-
-  this.options.port = opts.port || (global.location && location.port ?
-    location.port : (this.options.secure ? 443 : 80));
 
   this.connect();
 

--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -16,7 +16,6 @@ var isBrowser = typeof window != 'undefined';
 
 var SCSocket = function (opts) {
   var self = this;
-
   SCEmitter.call(this);
 
   this.id = null;
@@ -310,6 +309,7 @@ SCSocket.prototype.authenticate = function (signedAuthToken, callback) {
   var self = this;
 
   this.emit('#authenticate', signedAuthToken, function (err, authStatus) {
+
     if (err) {
       callback && callback(err, authStatus);
     } else {
@@ -318,7 +318,7 @@ SCSocket.prototype.authenticate = function (signedAuthToken, callback) {
         if (err) {
           self._onSCError(err);
         } else if (authStatus.isAuthenticated) {
-          self._setAuthStatus(authStatus.isAuthenticated);
+          self._setAuthStatus(signedAuthToken);
           SCEmitter.prototype.emit.call(self, 'authenticate', signedAuthToken);
         }
       });
@@ -602,9 +602,10 @@ SCSocket.prototype._trySubscribe = function (channel) {
   }
 };
 
-SCSocket.prototype.subscribe = function (channelName) {
+SCSocket.prototype.subscribe = function (channelName, options) {
+  options = options || {};
   var channel = this._channels[channelName];
-
+  var self = this;
   if (!channel) {
     channel = new SCChannel(channelName, this);
     this._channels[channelName] = channel;
@@ -612,7 +613,13 @@ SCSocket.prototype.subscribe = function (channelName) {
 
   if (channel.state == channel.UNSUBSCRIBED) {
     channel.state = channel.PENDING;
-    this._trySubscribe(channel);
+    if (!options.waitForAuth || this.isAuthenticated) {
+      self._trySubscribe(channel);
+    } else {
+      this.on('authenticate', function () {
+        self._trySubscribe(channel);
+      });
+    }
   }
 
   return channel;
@@ -756,18 +763,19 @@ SCSocket.prototype.watchers = function (channelName) {
   return this._channelEmitter.listeners(channelName);
 };
 
-SCSocket.prototype._setAuthStatus = function(encodedAuthToken) {
+SCSocket.prototype._setAuthStatus = function (encodedAuthToken) {
   var self = this;
   if (!encodedAuthToken) {
     this.isAuthenticated = false;
     return clearTimeout(this._tokenExpiration);
   }
+
   var decodedToken = jwtDecode(encodedAuthToken);
   var expiration = decodedToken.exp;
   if (!expiration) throw new Error('JWT does not have expiration');
   var ttl = expiration - Date.now();
   this.isAuthenticated = true;
-  this._tokenExpiration = setTimeout(function() {
+  this._tokenExpiration = setTimeout(function () {
     self.isAuthenticated = false
   }, ttl)
 }

--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -290,7 +290,7 @@ SCSocket.prototype.reconnect = function () {
 
 SCSocket.prototype.disconnect = function (code, data) {
   code = code || 1000;
-
+  this._setAuthStatus();
   if (this.state == this.OPEN) {
     var packet = {
       code: code,
@@ -763,14 +763,14 @@ SCSocket.prototype.watchers = function (channelName) {
   return this._channelEmitter.listeners(channelName);
 };
 
-SCSocket.prototype._setAuthStatus = function (encodedAuthToken) {
+SCSocket.prototype._setAuthStatus = function (signedAuthToken) {
   var self = this;
-  if (!encodedAuthToken) {
+  if (!signedAuthToken) {
     this.isAuthenticated = false;
     return clearTimeout(this._tokenExpiration);
   }
 
-  var decodedToken = jwtDecode(encodedAuthToken);
+  var decodedToken = jwtDecode(signedAuthToken);
   var expiration = decodedToken.exp;
   if (!expiration) throw new Error('JWT does not have expiration');
   var ttl = expiration - Date.now();

--- a/lib/scsocketCreator.js
+++ b/lib/scsocketCreator.js
@@ -1,7 +1,7 @@
 var SCSocket = require('./scsocket');
 
 var _connections = {};
-module.exports = function (options) {
+function connect(options) {
   var self = this;
   options = options || {};
   var isSecure = global.location && location.protocol == 'https:';
@@ -35,3 +35,26 @@ module.exports = function (options) {
   }
   return _connections[multiplexId];
 }
+
+function destroy(options) {
+  var self = this;
+  options = options || {};
+  var isSecure = global.location && location.protocol == 'https:';
+  var opts = {
+    port: options.port || global.location && location.port ? location.port : isSecure ? 443 : 80,
+    hostname: global.location && location.hostname,
+    path: '/socketcluster/'
+  };
+  for (var i in options) {
+    if (options.hasOwnProperty(i)) {
+      opts[i] = options[i];
+    }
+  }
+  var multiplexId = opts.hostname + ':' + opts.port + opts.path;
+  delete _connections[multiplexId];
+}
+
+module.exports = {
+  connect: connect,
+  destroy: destroy
+};

--- a/lib/scsocketCreator.js
+++ b/lib/scsocketCreator.js
@@ -4,7 +4,6 @@ var _connections = {};
 module.exports = function (options) {
   var self = this;
   options = options || {};
-  console.log('mplex', options.multiplex)
   var isSecure = global.location && location.protocol == 'https:';
   var opts = {
     port: options.port || global.location && location.port ? location.port : isSecure ? 443 : 80,

--- a/lib/scsocketCreator.js
+++ b/lib/scsocketCreator.js
@@ -1,0 +1,40 @@
+var SCSocket = require('./scsocket');
+
+var _connections = {};
+module.exports = function (options) {
+  var self = this;
+  options = options || {};
+  console.log('mplex', options.multiplex)
+  var isSecure = global.location && location.protocol == 'https:';
+  var opts = {
+    port: options.port || global.location && location.port ? location.port : isSecure ? 443 : 80,
+    autoReconnect: true,
+    autoProcessSubscriptions: true,
+    ackTimeout: 10000,
+    hostname: global.location && location.hostname,
+    path: '/socketcluster/',
+    secure: isSecure,
+    timestampRequests: false,
+    timestampParam: 't',
+    authEngine: null,
+    authTokenName: 'socketCluster.authToken',
+    binaryType: 'arraybuffer',
+    multiplex: true
+
+  };
+  for (var i in options) {
+    if (options.hasOwnProperty(i)) {
+      opts[i] = options[i];
+    }
+  }
+  console.log('mplex', opts.multiplex)
+  var multiplexId = opts.hostname + ':' + opts.port + opts.path;
+  debugger;
+  if (opts.multiplex === false) {
+    return new SCSocket(opts);
+  }
+  if (!_connections[multiplexId]) {
+    _connections[multiplexId] = new SCSocket(opts);
+  }
+  return _connections[multiplexId];
+}

--- a/lib/scsocketCreator.js
+++ b/lib/scsocketCreator.js
@@ -27,9 +27,7 @@ module.exports = function (options) {
       opts[i] = options[i];
     }
   }
-  console.log('mplex', opts.multiplex)
   var multiplexId = opts.hostname + ':' + opts.port + opts.path;
-  debugger;
   if (opts.multiplex === false) {
     return new SCSocket(opts);
   }

--- a/lib/sctransport.js
+++ b/lib/sctransport.js
@@ -3,6 +3,7 @@ var SCEmitter = require('sc-emitter').SCEmitter;
 var formatter = require('sc-formatter');
 var Response = require('./response').Response;
 var querystring = require('querystring');
+var jwtDecode = require('jwt-decode');
 
 var SCTransport = function (authEngine, options) {
   this.state = this.CLOSED;
@@ -86,15 +87,18 @@ SCTransport.prototype._onOpen = function () {
 
   this._resetPingTimeout();
 
-  this._handshake(function (err, status) {
-    if (err) {
-      self._onError(err);
-      self._onClose(4003);
-      self.socket.close(4003);
-    } else {
-      self.state = self.OPEN;
-      SCEmitter.prototype.emit.call(self, 'open', status);
-      self._resetPingTimeout();
+  this._handshake(function (token) {
+    return function (err, status) {
+      if (err) {
+        self._onError(err);
+        self._onClose(4003);
+        self.socket.close(4003);
+      } else {
+        self.state = self.OPEN;
+        status.authToken = token;
+        SCEmitter.prototype.emit.call(self, 'open', status);
+        self._resetPingTimeout();
+      }
     }
   });
 };
@@ -110,9 +114,15 @@ SCTransport.prototype._handshake = function (callback) {
       var options = {
         force: true
       };
+      //Do not send malformed tokens to the server
+      try {
+        var validToken = jwtDecode(token);
+      } catch (error) {
+        return callback(error);
+      }
       self.emit('#handshake', {
         authToken: token
-      }, options, callback);
+      }, options, callback(token));
     }
   });
 };
@@ -164,7 +174,7 @@ SCTransport.prototype._onMessage = function (message) {
           eventObject.callback(obj.error, obj.data);
         }
       }
-      if (obj.error) {
+      if (obj.error && eventObject.event !== "#subscribe") {
         this._onError(obj.error);
       }
     } else {


### PR DESCRIPTION
Sorry for combining issues, but there was a bit of overlap.

First up fixes #27. The external API doesn't change, but behind the scenes it caches connections based on url. Also offers up a `multiplex`option if you don't want to cache your connection. Finally, it offers a `destroy` method. you'd call it just like connect, eg `socketCluster.destroy(options)`. It looks up the id based on your options & deletes it from the cache.

Second fixes #29 
First, it puts 2 props on SCSocket: `isAuthenticated (boolean)` and `_tokenExpiration (timeoutHandler)`.
On every successful handshake, `#setAuthToken`, and `authenticate` method, it sets  `isAuthenticated` to true & calculates the time to live for that to remain true. Once that time is up, it turns false.
Also, on every disconnect or `#removeAuthToken` it turns false.
Additionally, I added a safety check to make sure the token is legit before it's sent off to the server. 

With that in place, it adds on `options` argument to the `subscribe` method. if `waitForAuth` is true, then it waits. before subscribing.



