### PR TITLE
Don't specify "socketcluster.js" as "main" in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "description": "Client side of SocketCluster",
   "version": "1.4.0",
   "homepage": "http://socketcluster.io",
-  "main": "socketcluster.js",
   "contributors": [
     {
       "name": "Jonathan Gros-Dubois",


### PR DESCRIPTION
This causes Node.js to load in the browserified version of the library, which gives errors about the code trying to access `document`, creating elements and other browser related stuff.

When `main` isn't specified in package.json, Node.js will by default read the index.js file which works just fine.
