### PR TITLE
Don't lose the context

### DIFF
--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -158,7 +158,7 @@ SCSocket.prototype._privateEventHandlerMap = {
     var isSubscribed = this.isSubscribed(undecoratedChannelName, true);
 
     if (isSubscribed) {
-      this._channelEmitter.emit(undecoratedChannelName, data.data);
+      this._channelEmitter.emit.call(this, undecoratedChannelName, data.data);
     }
   },
   '#kickOut': function (data) {


### PR DESCRIPTION
Without context, there were no callbacks to call.