### PR TITLE
optimize _onMessage

### DIFF
--- a/lib/sctransport.js
+++ b/lib/sctransport.js
@@ -166,12 +166,7 @@ SCTransport.prototype._onMessage = function (message) {
       this.socket.send('#2');
     }
   } else {
-    var obj;
-    try {
-      obj = this.parse(message);
-    } catch (err) {
-      obj = message;
-    }
+    var obj = this.parse(message);
     var event = obj.event;
 
     if (event) {


### PR DESCRIPTION
remove try catch.
`this.parse` refers to `sc-formatter` which already does the try/catch stuff. 
By taking it out of _onMessage V8 can optimize this & we'll get a little CPU speed boost on the client.
Test it to verify it works for your projects.

I promise I'll get around to rewriting the client soon :smile: