### PR TITLE
Perform disconnect on unload rather than beforeunload

### DIFF
--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -134,7 +134,7 @@ var SCSocket = function (opts) {
     if (global.attachEvent) {
       global.attachEvent('onunload', unloadHandler);
     } else if (global.addEventListener) {
-      global.addEventListener('beforeunload', unloadHandler, false);
+      global.addEventListener('unload', unloadHandler, false);
     }
   }
 };


### PR DESCRIPTION
Ref: #49 

Frees up beforeunload event for use by developer. For example to display a warning to the user that they are leaving the page and will lose their connection.
