### PR TITLE
Fix for web worker

### DIFF
--- a/lib/sctransport.js
+++ b/lib/sctransport.js
@@ -57,7 +57,7 @@ SCTransport.prototype.open = function () {
   this.state = this.CONNECTING;
   var uri = this.uri();
 
-  var wsSocket = new WebSocket(uri, null, this.options);
+  var wsSocket = new WebSocket(uri, [], this.options);
   wsSocket.binaryType = this.options.binaryType;
   this.socket = wsSocket;
 

--- a/lib/ws-browser.js
+++ b/lib/ws-browser.js
@@ -1,5 +1,9 @@
-
-var global = typeof window != 'undefined' && window || (function() { return this; })();
+var global;
+if (typeof WorkerGlobalScope !== 'undefined') {
+  global = self;
+} else {
+  global = typeof window != 'undefined' && window || (function() { return this; })();
+}
 
 var WebSocket = global.WebSocket || global.MozWebSocket;
 


### PR DESCRIPTION
Since window isn't available in a web worker it was not able to find WebSocket, which is located at self.WebSocket.