### PR TITLE
Make client disconnect after number of attempts

### DIFF
--- a/socketcluster.js
+++ b/socketcluster.js
@@ -336,6 +336,9 @@ var SCSocket = function (opts) {
     if (reconnectOptions.maxDelay == null) {
       reconnectOptions.maxDelay = 60000;
     }
+	if(reconnectOptions.mexAttempts == null){
+		reconnectOptions.maxAttempts = 1000; // default? ///
+	}
   }
 
   if (this.options.subscriptionRetryOptions == null) {
@@ -704,6 +707,11 @@ SCSocket.prototype._tryReconnect = function (initialDelay) {
 
   clearTimeout(this._reconnectTimeoutRef);
 
+  ///// stop recoonecting after reaching max. number of connection attempts ///
+  if( exponent >= reconnectOptions.maxAttempts ){
+	  return; 
+  }
+  
   this.pendingReconnect = true;
   this.pendingReconnectTimeout = timeout;
   this._reconnectTimeoutRef = setTimeout(function () {


### PR DESCRIPTION
Just thought it would be great to have an option on client side that defines the maximum number of attempts for the client to keep reconnecting. ( I set 1000 attempts as default. ) . Is it something that could be implemented in the sc-client or is it better approach to have this handled inside my app instead?