### PR TITLE
replace lodash implementation of cloneDeep with a smaller implementation

### DIFF
--- a/lib/scsocket.js
+++ b/lib/scsocket.js
@@ -7,7 +7,7 @@ var SCTransport = require('./sctransport').SCTransport;
 var querystring = require('querystring');
 var LinkedList = require('linked-list');
 var base64 = require('base-64');
-var cloneDeep = require('lodash.clonedeep');
+var clone = require('clone');
 
 var scErrors = require('sc-errors');
 var InvalidArgumentsError = scErrors.InvalidArgumentsError;
@@ -658,7 +658,7 @@ SCSocket.prototype._emit = function (event, data, callback) {
   var eventNode = new LinkedList.Item();
 
   if (this.options.cloneData) {
-    eventNode.data = cloneDeep(eventObject);
+    eventNode.data = clone(eventObject);
   } else {
     eventNode.data = eventObject;
   }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "base-64": "0.1.0",
     "linked-list": "0.1.0",
-    "lodash.clonedeep": "4.5.0",
+    "clone": "2.1.x",
     "querystring": "0.2.0",
     "sc-channel": "1.0.x",
     "sc-emitter": "1.x.x",


### PR DESCRIPTION
Not sure if you want to do this or not, but I figured I would go ahead and throw this PR together for review. Definitely needs heavy testing before merging, as well as consideration of other implementations.

Conversation found here: https://gitter.im/SocketCluster/socketcluster?at=587fb5ce074f7be763e9142e

Another suggestion by @mauritslamers is to consider SproutCore's implementation. I'm down for whatever works best and brings the filesize down as much as possible 😄 