### PR TITLE
Update ws to 3.3.3 (security vulnerability)

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "sc-channel": "~1.2.0",
     "sc-errors": "~1.3.3",
     "sc-formatter": "~3.0.1",
-    "ws": "3.1.0"
+    "ws": "3.3.3"
   },
   "browser": {
     "ws": "./lib/ws-browser.js"


### PR DESCRIPTION
[Node Security](https://github.com/nodesecurity/nsp) scan is showing warnings against ws 3.1.0 related to https://snyk.io/vuln/npm:ws:20171108