### PR TITLE
Restrict simultaneous usage of host/hostname/port options fixes #105

### DIFF
--- a/lib/scsocketcreator.js
+++ b/lib/scsocketcreator.js
@@ -52,10 +52,16 @@ function create(options) {
       ' the hostname and the port number in the format "hostname:port".');
   }
 
-  if ((options.host && options.port) || (options.host && options.hostname)) {
+  if (options.host && options.hostname) {
     throw new InvalidArgumentsError('The host option should already include' +
       ' the hostname and the port number in the format "hostname:port"' +
-      ' - Use either both, hostname and port, options together or the host option alone.');
+      ' - Because of this, you should never use host and hostname options together.');
+  }
+
+  if (options.host && options.port) {
+    throw new InvalidArgumentsError('The host option should already include' +
+      ' the hostname and the port number in the format "hostname:port"' +
+      ' - Because of this, you should never use host and port options together.');
   }
 
   var isSecureDefault = isUrlSecure();

--- a/lib/scsocketcreator.js
+++ b/lib/scsocketcreator.js
@@ -47,17 +47,22 @@ function create(options) {
 
   options = options || {};
 
-  if (options.host && options.port) {
-    throw new InvalidArgumentsError('The host option should already include the' +
-      ' port number in the format hostname:port - Because of this, the host and port options' +
-      ' cannot be specified together; use the hostname option instead');
+  if (options.host && !options.host.match(/[^:]+:\d{2,5}/)) { // should be "hostname:port"
+    throw new InvalidArgumentsError('The host option should include both' +
+      ' the hostname and the port number in the format "hostname:port".');
+  }
+
+  if ((options.host && options.port) || (options.host && options.hostname)) {
+    throw new InvalidArgumentsError('The host option should already include' +
+      ' the hostname and the port number in the format "hostname:port"' +
+      ' - Because of this, the host and port options cannot be specified together.' +
+      ' Use either hostname and port options together or host option alone.');
   }
 
   var isSecureDefault = isUrlSecure();
 
   var opts = {
     port: getPort(options, isSecureDefault),
-    hostname: global.location && location.hostname || '',
     hostname: global.location && location.hostname || 'localhost',
     path: '/socketcluster/',
     secure: isSecureDefault,

--- a/lib/scsocketcreator.js
+++ b/lib/scsocketcreator.js
@@ -57,7 +57,7 @@ function create(options) {
 
   var opts = {
     port: getPort(options, isSecureDefault),
-    hostname: global.location && location.hostname,
+    hostname: global.location && location.hostname || '',
     path: '/socketcluster/',
     secure: isSecureDefault,
     autoConnect: true,

--- a/lib/scsocketcreator.js
+++ b/lib/scsocketcreator.js
@@ -58,6 +58,7 @@ function create(options) {
   var opts = {
     port: getPort(options, isSecureDefault),
     hostname: global.location && location.hostname || '',
+    hostname: global.location && location.hostname || 'localhost',
     path: '/socketcluster/',
     secure: isSecureDefault,
     autoConnect: true,

--- a/lib/scsocketcreator.js
+++ b/lib/scsocketcreator.js
@@ -55,8 +55,7 @@ function create(options) {
   if ((options.host && options.port) || (options.host && options.hostname)) {
     throw new InvalidArgumentsError('The host option should already include' +
       ' the hostname and the port number in the format "hostname:port"' +
-      ' - Because of this, the host and port options cannot be specified together.' +
-      ' Use either hostname and port options together or host option alone.');
+      ' - Use either both, hostname and port, options together or the host option alone.');
   }
 
   var isSecureDefault = isUrlSecure();


### PR DESCRIPTION
Otherwise `hostname` is `undefined` if you run the client via Node.js