### PR TITLE
Fix disconnectOnUnload check

### DIFF
--- a/lib/scclientsocket.js
+++ b/lib/scclientsocket.js
@@ -38,7 +38,7 @@ var SCClientSocket = function (opts) {
   this.connectTimeout = opts.connectTimeout;
   this.ackTimeout = opts.ackTimeout;
   this.channelPrefix = opts.channelPrefix || null;
-  this.disconnectOnUnload = opts.disconnectOnUnload == null ? true : opts.disconnectOnUnload;
+  this.disconnectOnUnload = opts.disconnectOnUnload === undefined ? true : opts.disconnectOnUnload;
   this.authTokenName = opts.authTokenName;
 
   // pingTimeout will be ackTimeout at the start, but it will


### PR DESCRIPTION
change to a strict equality check against undefined.

This fixes a really annoying bug with the current implementation. Currently we check to see if disconnectOnUnload is undefined by comparing to null. But because we are using loose equality check, this means disconnectOnUnload will always evaluate to true, because false is also loosely equal to null! This is really annoying as it will always call the handler, even when disconnectOnUnload is set to false. Drove me crazy trying to find the source of the problem